### PR TITLE
Add codesections topic #1

### DIFF
--- a/raku-advent-2020/authors.md
+++ b/raku-advent-2020/authors.md
@@ -18,3 +18,5 @@ reminders.
 * guifa/alabamenhu: Mastering Time
 * melezhik: Multi languages automation using Sparrow and Raku ( could be interesting for people coming from different languages )
 * moritz <moritz.lenz@gmail.com>: Developing declarative APIs in Raku
+* codesections <daniel@codesections.com>: A scaffold for solving
+  Advent of Code puzzles in Raku


### PR DESCRIPTION
I'm volunteering to write a Raku Advent Calendar post, which I am tentatively planning to title "Advent of (Code|Raku)".

My post will have 3 goals:
  - Introduce Raku programmers to Advent of Code
  https://adventofcode.com/2019/about
  - Introduce AoC participants to Raku
  - Launch a GitHub repo that contains both a template/scaffold for
  AoC solutions (e.g., a set of CLI scripts that handle basic input
  and output) and a place for people to submit different solutions to
  compare and contrast

Because this will introduce AoC, which also runs December 1-25, it probably makes sense to schedule this post early in the series, if possible.