### PR TITLE
Register curl clone post

### DIFF
--- a/raku-advent-2020/authors.md
+++ b/raku-advent-2020/authors.md
@@ -21,3 +21,4 @@ reminders.
 * codesections <daniel@codesections.com>: A scaffold for solving
   Advent of Code puzzles in Raku
 * Scimon <simon.proctor@gmail.com> : Something something Junctions Something (more later but I figure a good article about Junctions would be nice).
+* jjatria: Emulating curl with HTTP::Tiny


### PR DESCRIPTION
While developing HTTP::Tiny I wrote a curl clone that allowed me to make sure it worked and to compare its results with the real curl.

This post would work as a showcase of the kind of things that the library supports and the HTTP::Tiny interface allows.