### PR TITLE
Fixed year reference, eased future changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Articles up to 2018 can be found in the
 See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed instructions for
 authors.
 
-The current year's list of authors is in the file
-[raku-advent-2020/authors.md](raku-advent-2021/authors.md). Add
-yourself to the list via [pull request](/Raku/advent/pulls), and
-contribute your article as soon as it's ready.
+The current year's list of authors is in the file [authors.md][]. Add yourself
+to the list via [pull request](/Raku/advent/pulls), and contribute your article
+as soon as it's ready.
 
 ## License: Artistic 2.0
+
+[authors.md]: raku-advent-2021/authors.md


### PR DESCRIPTION
The text linking to the authors list was still referring to 2020.

The link has been moved on the bottom to simplify future updates.