### PR TITLE
docs:Added proposed titles for 2025 advent articles.

### DIFF
--- a/raku-advent-2025/authors.md
+++ b/raku-advent-2025/authors.md
@@ -15,9 +15,9 @@ Please also send an easy and fast way to contact you to liz at raku.rocks and li
 reminders.
 
 1. yourname: Your Title
-2. ..
-3. ..
-4. ..
+2. antononcube: Doing Data Science with Raku
+3. antononcube: Robust code generation combining grammars and LLMs
+4. antononcube: Monadic programming examples
 5. ..
 6. ..
 7. ..


### PR DESCRIPTION
All of the three articles I propose are written to a large degree:

1. [Doing Data Science with Raku](https://github.com/antononcube/RakuForPrediction-blog/blob/main/Articles/Raku-for-Data-Science-and-LLMs.md)
2. [Robust code generation combining grammars and LLMs](https://github.com/antononcube/Raku-ML-SparseMatrixRecommender/blob/main/docs/Code-generation.ipynb)
3. [Monadic programming examples](https://github.com/antononcube/RakuForPrediction-blog/blob/main/Notebooks/Jupyter/Monadic-programming-examples.ipynb)

The 2nd one, "Robust code generation combining grammars and LLMs", probably has to be renamed. So far, the linked notebook shows only two types of combinations of grammar-based interpreters and LLMs, both through LLM graphs. (And there are several more at different grammar-class levels, i.e. not using LLM graphs.)